### PR TITLE
downcase username before saving a bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem 'local_time'
 
 gem 'rack-attack'
 
+gem 'route_downcaser'
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,8 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    route_downcaser (1.2.3)
+      activesupport (>= 3.2)
     ruby-vips (2.1.0)
       ffi (~> 1.12)
     rubyzip (2.3.0)
@@ -301,6 +303,7 @@ DEPENDENCIES
   rails (~> 6.1.3)
   rails-bootstrap-tabs (~> 0.2.4)
   rails-i18n
+  route_downcaser
   sass-rails (>= 6)
   selenium-webdriver
   spring

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -32,6 +32,13 @@ class Bot < ApplicationRecord
 
   validate :tag_list_count
 
+  before_save :downcase_username
+
+  # remove all capitals from usernames
+  def downcase_username
+    username.downcase!
+  end
+
   # Assign an API key on create
   before_create do |bot|
     bot.api_key = bot.generate_api_key

--- a/app/views/bots/show.html.erb
+++ b/app/views/bots/show.html.erb
@@ -43,7 +43,7 @@
         <% if current_guest or current_developer %>
           <div class="follow-button">
             <% if current_developer && @bot.developer == current_developer %>
-              <%= link_to 'Edit bot', edit_bot_path(id: @bot.username), class: 'btn btn-primary' %>
+              <%= link_to 'Edit bot', edit_bot_path(@bot), class: 'btn btn-primary' %>
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
Closes #214 

Downcase username before saving. This ensures username and slugs are equal.
 
Line edited in bot's profile: passing @ bot makes Rails look for the correct attribute used on find_bot. This solves the issue on edit page but downcasing usernames seems to be the best idea.