### PR TITLE
validate cover image size on bot's model

### DIFF
--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -108,7 +108,7 @@ class Bot < ApplicationRecord
   def validate_maximum_cover_image_size
     if cover.path
       image = MiniMagick::Image.open(cover.path)
-      unless image[:width] < 1280 && image[:height] < 360
+      unless image[:width] <= 1280 && image[:height] <= 360
         errors.add :cover, "should be 1280x360px maximum!" 
       end
     end 

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -89,7 +89,7 @@ class Developer < ApplicationRecord
   def validate_maximum_cover_image_size
     if cover.path
       image = MiniMagick::Image.open(cover.path)
-      unless image[:width] < 1280 && image[:height] < 360
+      unless image[:width] <= 1280 && image[:height] <= 360
         errors.add :cover, "should be 1280x360px maximum!" 
       end
     end 


### PR DESCRIPTION
Closes #216 

Validates bot's cover image size. We'd forgotten to check it for bots too.