### PR TITLE
Devise confirmation instructions Mailer

### DIFF
--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,5 +1,5 @@
 class Developer < ApplicationRecord
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :validatable, authentication_keys: [:login]
 
   extend FriendlyId
@@ -93,5 +93,5 @@ class Developer < ApplicationRecord
         errors.add :cover, "should be 1280x360px maximum!" 
       end
     end 
-  end 
+  end
 end

--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -1,5 +1,5 @@
 class Guest < ApplicationRecord
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :validatable, authentication_keys: [:login]
 
   attr_writer :login
@@ -52,5 +52,4 @@ class Guest < ApplicationRecord
       errors.add(:username, :already_taken)
     end
   end
-
 end

--- a/app/views/developers/mailer/confirmation_instructions.html.erb
+++ b/app/views/developers/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome <%= @email %>!</p>
+<p>Welcome to IA-e <%= @resource.name %>!</p>
 
 <p>You can confirm your account email through the link below:</p>
 

--- a/app/views/developers/mailer/confirmation_instructions.text.erb
+++ b/app/views/developers/mailer/confirmation_instructions.text.erb
@@ -1,0 +1,5 @@
+Welcome to IA-e <%= @resource.name %>!
+
+You can confirm your account email through the link below:
+
+<%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %>

--- a/app/views/guests/mailer/confirmation_instructions.html.erb
+++ b/app/views/guests/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome <%= @email %>!</p>
+<p>Welcome to IA-e <%= @resource.username %>!</p>
 
 <p>You can confirm your account email through the link below:</p>
 

--- a/app/views/guests/mailer/confirmation_instructions.text.erb
+++ b/app/views/guests/mailer/confirmation_instructions.text.erb
@@ -1,0 +1,5 @@
+Welcome to IA-e <%= @resource.username %>!
+
+You can confirm your account email through the link below:
+
+<%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,5 +74,21 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
+  # email delivery config
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  # To actually send emails on development, turn it to true
+  config.action_mailer.perform_deliveries = false
+
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    user_name:      ENV['SENDMAIL_USERNAME'],
+    password:       ENV['SENDMAIL_PASSWORD'],
+    domain:         'localhost:3000', # considering you're running the app on port 3000
+    address:       'smtp.gmail.com',
+    port:          '587',
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,4 +117,19 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  # email delivery config
+  config.action_mailer.default_url_options = { host: ENV['MAIL_HOST'] }
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    user_name:      ENV['SENDMAIL_USERNAME'],
+    password:       ENV['SENDMAIL_PASSWORD'],
+    domain:         ENV['MAIL_HOST'],
+    address:       'smtp.gmail.com',
+    port:          '587',
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 end

--- a/db/migrate/20210427130120_add_confirmable_to_developers.rb
+++ b/db/migrate/20210427130120_add_confirmable_to_developers.rb
@@ -1,0 +1,16 @@
+class AddConfirmableToDevelopers < ActiveRecord::Migration[6.1]
+  def change
+    change_table :developers do |t|
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      t.string   :unlock_token # Only if unlock strategy is :email or :both
+      t.datetime :locked_at
+    end
+  end
+end

--- a/db/migrate/20210427130351_add_confirmable_to_guests.rb
+++ b/db/migrate/20210427130351_add_confirmable_to_guests.rb
@@ -1,0 +1,16 @@
+class AddConfirmableToGuests < ActiveRecord::Migration[6.1]
+  def change
+    change_table :guests do |t|
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      t.string   :unlock_token # Only if unlock strategy is :email or :both
+      t.datetime :locked_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_13_013759) do
+ActiveRecord::Schema.define(version: 2021_04_27_130351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,13 @@ ActiveRecord::Schema.define(version: 2021_04_13_013759) do
     t.boolean "verified"
     t.string "cover"
     t.boolean "accept_terms"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
     t.index ["email"], name: "index_developers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_developers_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_developers_on_slug", unique: true
@@ -102,6 +109,13 @@ ActiveRecord::Schema.define(version: 2021_04_13_013759) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "username"
     t.boolean "accept_terms"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
     t.index ["email"], name: "index_guests_on_email", unique: true
     t.index ["reset_password_token"], name: "index_guests_on_reset_password_token", unique: true
     t.index ["username"], name: "index_guests_on_username", unique: true

--- a/lib/tasks/confirmations.rake
+++ b/lib/tasks/confirmations.rake
@@ -1,0 +1,21 @@
+# This task is going to be run only once. Since the mail service for devise wasn't being used,
+# existing users hadn't received any confirmation email. Now confirmation is required 
+# so these existing users are going to be logged out and be asked to confirm their emails.
+# For this to be possible, this task will identify users who has "null" as value for "confirmation_sent_at"
+# and send them confirmation instructions. 
+
+namespace :confirmations do
+  desc "Send email confirmation instructions to every user who hasn't received it"
+  task import: :environment do
+    guests = Guest.where(confirmation_sent_at: nil)
+    developers = Developer.where(confirmation_sent_at: nil)
+
+    guests.find_each do |g|
+      g.send_confirmation_instructions
+    end
+
+    developers.find_each do |d|
+      d.send_confirmation_instructions
+    end
+  end
+end


### PR DESCRIPTION
### Set up Devise for sending confirmation instructions to new users

**OBS: No one can log-in before confirming email.**

**Important:** this configuration was made to send emails using a Gmail account. For testing with your own account you must create an app password on your Gmail account and use it as SENDMAIL_PASSWORD. **To actually send emails on development mode check development.rb file for instructions.**

Since we have existing users a task was created to send confirmations instructions to existing accounts. It can be found at app/lib/tasks. 

Closes #228 
