### PR TITLE
Fix cross models visits

### DIFF
--- a/app/controllers/concerns/accessible.rb
+++ b/app/controllers/concerns/accessible.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This module will handle cross models visits.
+# i.e. a guest cannot visit some developers views (such as sign-in) when logged-in
+# as guest, and viceversa. They will be redirected to feed.
+# This avoid a user logging-in twice as two different model (and messing with tokens).
+module Accessible
+  extend ActiveSupport::Concern
+  included do
+    before_action :check_user
+  end
+
+  protected
+
+  def check_user
+    if current_guest
+      flash.clear
+      redirect_to(posts_path) and return
+    elsif current_developer
+      flash.clear
+      redirect_to(posts_path) and return
+    end
+  end
+end

--- a/app/controllers/developers/registrations_controller.rb
+++ b/app/controllers/developers/registrations_controller.rb
@@ -3,6 +3,7 @@
 class Developers::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: %i[create]
   before_action :configure_account_update_params, only: %i[update]
+  include Accessible
 
   # GET /resource/sign_up
   # def new

--- a/app/controllers/developers/sessions_controller.rb
+++ b/app/controllers/developers/sessions_controller.rb
@@ -2,6 +2,8 @@
 
 class Developers::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  include Accessible
+  skip_before_action :check_user, only: :destroy
 
   # GET /resource/sign_in
   # def new

--- a/app/controllers/guests/registrations_controller.rb
+++ b/app/controllers/guests/registrations_controller.rb
@@ -3,6 +3,7 @@
 class Guests::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  include Accessible
 
   # GET /resource/sign_up
   # def new

--- a/app/controllers/guests/sessions_controller.rb
+++ b/app/controllers/guests/sessions_controller.rb
@@ -2,6 +2,8 @@
 
 class Guests::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  include Accessible
+  skip_before_action :check_user, only: :destroy
 
   # GET /resource/sign_in
   # def new


### PR DESCRIPTION
Redirect users when they try to access another model's sign-in or sign-up pages.
This is called "cross models visits", for more information you can check [Devise's docs](https://github.com/heartcombo/devise/wiki/How-to-Setup-Multiple-Devise-User-Models).

Now guests cannot visit developers' sign-in and sign-up pages when logged in as Guest or vice versa. They're redirected back to feed.

Fixes #256 