### PR TITLE
Improve Rack-attack middleware

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress CSS using a preprocessor.
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,29 +1,67 @@
-class Rack::Attack
+# frozen_string_literal: true
 
-    ### Configure Cache ###
+# RackAttack https://github.com/rack/rack-attack
+module Rack
+  # Mitigates abusive requests
+  class Attack
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
 
-    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new 
+    # Requests from localhost will be allowed despite matching any number of blocklists or throttles
+    Rack::Attack.safelist_ip('127.0.0.1')
 
-    ### Throttle Spammy Clients ###
+    # Throttle all requests to root path by IP (50rpm/IP)
+    throttle('req/ip', limit: 50, period: 1.minute, &:ip)
 
-    # Throttle all requests by IP (60rpm)
-
-    # Max 300 requests per 5 minutes
-    throttle('req/ip', limit: 200, period: 5.minutes) do |req|
-      req.ip 
+    # Ban IP for 1 hour after 200 requests in 5 minutes
+    Rack::Attack.blocklist('ban on too many requests') do |req|
+      Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 200, findtime: 5.minutes, bantime: 1.hour) do
+        true
+      end
     end
 
-    # Prevent too many POST requests on sing in pages
-
-    throttle('developers/sign_in/ip', limit: 20, period: 20.seconds) do |req|
-        if req.path == '/developers/sign_in' && req.post?
-            req.ip
-        end     
+    # Prevent too many POST requests on sing-in pages
+    throttle('sign_in/ip', limit: 20, period: 20.seconds) do |req|
+      if req.path == '/developers/sign_in' && req.post?
+        req.ip
+      elsif req.path == '/guests/sign_in' && req.post?
+        req.ip
+      end
     end
 
-    throttle('guests/sign_in/ip', limit: 20, period: 20.seconds) do |req|
-        if req.path == '/guests/sign_in' && req.post?
-            req.ip
-        end     
+    # Ban IP for 12 hours after 20 sign-ups in 1 hour
+    # Prevents a single user from creating too many accounts
+    Rack::Attack.blocklist('ban on too many sign-ups') do |req|
+      Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 20, findtime: 1.hour, bantime: 12.hours) do
+        ((req.path == '/developers/sign_up' || req.path == '/developers') ||
+          (req.path == '/guests/sign_up' || req.path == '/guests')) && req.post?
+      end
     end
-end 
+  end
+
+  # Ban IP for 12 hours after 50 sign-in attempts in 5 minutes
+  Rack::Attack.blocklist('ban on too man sing-ins attempts') do |req|
+    Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 50, findtime: 5.minutes, bantime: 12.hours) do
+      (req.path == '/guests/sign_in' || req.path == '/developers/sign_in') && req.post?
+    end
+  end
+
+  # Using 503 because it may make attacker think that they have successfully
+  # DOSed the site.
+  Rack::Attack.blocklisted_response = lambda do |_env|
+    [503, {}, ["Blocked\n"]]
+  end
+
+  Rack::Attack.throttled_response = lambda do |_env|
+    [503, {}, ["Server error\n"]]
+  end
+end
+
+# Log rack-attack events
+ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, _start, _finish, _request_id, payload|
+  req = payload[:request]
+  remote_ip = req.env['HTTP_X_FORWARDED_FOR'].presence || req.env['REMOTE_ADDR'].presence
+  url = req.env['REQUEST_URI'].presence
+  Rails.logger.info '[Rack::Attack][PostApp]' \
+                    " remote_ip: \"#{remote_ip}\"," \
+                    " request_uri: #{url}"
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -40,7 +40,7 @@ module Rack
 
   # Ban IP for 12 hours after 50 sign-in attempts in 5 minutes
   Rack::Attack.blocklist('ban on too man sing-ins attempts') do |req|
-    Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 50, findtime: 5.minutes, bantime: 12.hours) do
+    Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 50, findtime: 5.minutes, bantime: 24.hours) do
       (req.path == '/guests/sign_in' || req.path == '/developers/sign_in') && req.post?
     end
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -9,7 +9,7 @@ module Rack
     # Requests from localhost will be allowed despite matching any number of blocklists or throttles
     Rack::Attack.safelist_ip('127.0.0.1')
 
-    # Throttle all requests to root path by IP (50rpm/IP)
+    # Throttle all requests to any route by IP (50rpm/IP)
     throttle('req/ip', limit: 50, period: 1.minute, &:ip)
 
     # Ban IP for 1 hour after 200 requests in 5 minutes


### PR DESCRIPTION
**Changes made:**

- Force SSL (TLS) on production environment;
- Block IPs of misbehaving clients;
- Add localhost to safelist;
- Log rack-attack events.

IPs will be blocked in 3 scenarios:

1. Too many requests in a period of time (5 minutes). Rack-attack will count any kind of request to any route for 1 minute and 5 minutes. Client will get a 503 response after 50 requests in 1 minute, but they aren't going to be blocked. If this repeats to the point of making 200 requests in 5 minutes their IP is going to be blocked for 1 hour.
2. Multiple "sign-ups" in 1 hour. Maximum is 20 in an hour. After making 20 POST requests to sign-up pages the client is going to be blocked for 12 hours. This prevents a single user from creating too many accounts. A drawback is that it doesn't matter if a user is legitimately trying to create an account (and failed 20 times), even though I believe 20 attempts are good enough for anyone to successfully create an account. This can be discussed and I accept suggestions. 
3. Multiple "sign-ins" in 1 hour. Maximum is 50 POST requests on sign-in pages in 5 minutes. After reaching that limit the client's IP is going to be blocked for 12 hours. This could be extended to maximum in 1 hour or on a day, to prevent users from locking someone's else account on purpose. What do you guys think? 