### PR TITLE
Identify Locales Automatically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'route_downcaser'
 
 gem 'strong_password', '~> 0.0.9'
 
+gem 'http_accept_language'
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
       activerecord (>= 4.0.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    http_accept_language (2.1.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
@@ -290,6 +291,7 @@ DEPENDENCIES
   devise
   file_validators
   friendly_id (~> 5.4.0)
+  http_accept_language
   jbuilder (~> 2.11)
   jquery-rails
   listen (~> 3.5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,17 +1,30 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_locale
 
-  # returns current user whether it's a guest or a developer
+  # Returns current user whether it's a guest or a developer
   def current_user
     current_developer || current_guest
   end
 
   protected
 
-  # adiciona username e name como parâmetros adicionais
+  # Permit username and name as strong parameters for Devise Sign-up
   def configure_permitted_parameters
     added_attrs = %i[name username email password password_confirmation remember_me]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+  end
+
+  private
+
+  # Set locale for current user
+  # Tries to get locale from user's preferences. Then, from user's browser locale
+  # and, if both fails, sets to default locale (en).
+  def set_locale
+    I18n.locale = current_user.try(:locale) || http_accept_language.compatible_language_from(I18n.available_locales) ||
+                  I18n.default_locale
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,12 @@ module Iae
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # I18n config
+    I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+    I18n.default_locale = :en
+
+    I18n.available_locales = %i[en pt]
   end
 end

--- a/config/locales/devise.pt.yml
+++ b/config/locales/devise.pt.yml
@@ -1,0 +1,65 @@
+# Portuguese translation for Devise flash messages
+
+pt:
+  devise:
+    confirmations:
+      confirmed: "Sua conta foi confirmada com sucesso."
+      send_instructions: "Você receberá um email com instruções para confirmar sua conta em alguns minutos."
+      send_paranoid_instructions: "Se seu endereço de email existir em nosso banco de dados, você receberá um email com instruções para confirmar sua conta em alguns minutos."
+    failure:
+      already_authenticated: "Você já está logado."
+      inactive: "Sua conta ainda não foi ativada."
+      invalid: "%{authentication_keys} ou senha inválida."
+      locked: "Sua conta está bloqueada."
+      last_attempt: "Você tem mais uma tentativa antes de sua conta ser bloqueada."
+      not_found_in_database: "%{authentication_keys} ou senha inválida."
+      timeout: "Sua sessão expirou. Por favor, faça login novamente para continuar."
+      unauthenticated: "Você precisa entrar ou registrar-se antes de continuar."
+      unconfirmed: "Você precisa confirmar seu endereço de email antes de continuar."
+    mailer:
+      confirmation_instructions:
+        subject: "Instruções de confirmação"
+      reset_password_instructions:
+        subject: "Instruções de redefinição de senha"
+      unlock_instructions:
+        subject: "Instruções de desbloqueio"
+      email_changed:
+        subject: "Email alterado"
+      password_change:
+        subject: "Senha alterada"
+    omniauth_callbacks:
+      failure: "Não foi possível autenticá-lo em %{kind} porque \"%{reason}\"."
+      success: "Autenticado com sucesso em %{kind}."
+    passwords:
+      no_token: "Você não pode acessar esta página para redefinição, por favor tenha certeza de que usou a URL completa recebida."
+      send_instructions: "Você receberá, em breve, um email com instruções de como redefinir sua senha."
+      send_paranoid_instructions: "Se seu endereço de email existir em nosso banco de dados, você receberá um link de redefinição de senha em alguns minutos."
+      updated: "Sua senha foi atualizada com sucesso. Você agora está logado."
+      updated_not_active: "Sua senha foi atualizada com sucesso."
+    registrations:
+      destroyed: "Tchau! Sua conta foi cancelada com êxito. Esperamos ver você de novo em breve!"
+      signed_up: "Bem-vindo! Você se registrou com êxito."
+      signed_up_but_inactive: "Você se registrou com êxito. Entretanto, precisa confirmar sua conta antes de fazer login."
+      signed_up_but_locked: "Você se registrou com sucesso. Entretando, sua conta está bloqueada, e não foi possível fazer login."
+      signed_up_but_unconfirmed: "Uma mensagem com um link de confirmação foi enviada para seu endereço de email. Por favor, siga o link para ativar sua conta."
+      update_needs_confirmation: "Você atualizou sua conta com sucesso, mas nós precisamos verificar seu endereço de email. Por favor, cheque sua caixa de entrada e siga o link recebido."
+      updated: "Sua conta foi atualizada com sucesso."
+      updated_but_not_signed_in: "Sua conta foi atualizada com sucesso, porém sua senha foi alterada, você necessita fazer login novamente."
+    sessions:
+      signed_in: "Logado com sucesso."
+      signed_out: "Saiu com sucesso."
+      already_signed_out: "Saiu com sucesso."
+    unlocks:
+      send_instructions: "Você receberá um email com instruções para desbloquear sua conta em alguns minutos."
+      send_paranoid_instructions: "Se sua conta existir, você receberá um email com instruções para desbloqueá-la em alguns minutos."
+      unlocked: "Sua conta foi desbloqueada com sucesso. Por favor, faça login para continuar."
+  errors:
+    messages:
+      already_confirmed: "já foi confirmado, por favor faça login"
+      confirmation_period_expired: "precisava ser confirmada em %{period}, por favor solicite um novo link"
+      expired: "expirou, por favor solicite uma nova"
+      not_found: "não encontrado"
+      not_locked: "não está bloqueada"
+      not_saved:
+        one: "1 erro impediu que %{resource} fosse salvo(a):"
+        other: "%{count} erros impediram que %{resource} fosse salvo(a):"


### PR DESCRIPTION
Identify locale based on current user preferences*. If the user hasn't chosen any language (e.g. a new user), the locale will be set based on the HTTP_ACCEPT_LANGUAGE header (if the locale is currently available). The fallback is default locale (en).

*This is not yet implemented.
Closes #314 