### PR TITLE
Users locale preferences

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,21 +1,12 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_locale
+  helper_method :current_user
 
   # Returns current user whether it's a guest or a developer
   def current_user
     current_developer || current_guest
-  end
-
-  protected
-
-  # Permit username and name as strong parameters for Devise Sign-up
-  def configure_permitted_parameters
-    added_attrs = %i[name username email password password_confirmation remember_me]
-    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
-    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
   end
 
   private

--- a/app/controllers/developers/registrations_controller.rb
+++ b/app/controllers/developers/registrations_controller.rb
@@ -1,64 +1,70 @@
 # frozen_string_literal: true
 
-class Developers::RegistrationsController < Devise::RegistrationsController
-  include Accessible
-  before_action :configure_sign_up_params, only: %i[create]
-  before_action :configure_account_update_params, only: %i[update]
-  skip_before_action :check_user, only: %i[edit update cancel]
+module Developers
+  class RegistrationsController < Devise::RegistrationsController
+    include Accessible
+    before_action :configure_sign_up_params, only: %i[create]
+    before_action :configure_account_update_params, only: %i[update]
+    skip_before_action :check_user, only: %i[edit update cancel]
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+    # GET /resource/sign_up
+    # def new
+    #   super
+    # end
 
-  # POST /resource
-  # def create
-  #   super
-  # end
+    # POST /resource
+    # def create
+    #   super
+    # end
 
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
+    # GET /resource/edit
+    # def edit
+    #   super
+    # end
 
-  # PUT /resource
-  # def update
-  #   super
-  # end
+    # PUT /resource
+    # def update
+    #   super
+    # end
 
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
+    # DELETE /resource
+    # def destroy
+    #   super
+    # end
 
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
+    # GET /resource/cancel
+    # Forces the session data which is usually expired after sign
+    # in to be expired now. This is useful if the user wants to
+    # cancel oauth signing in/up in the middle of the process,
+    # removing all OAuth session data.
+    # def cancel
+    #   super
+    # end
 
-  protected
+    protected
 
-  # Permit avatar and cover for sign_up
-  def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:avatar, :cover])
+    # Permit avatar and cover for sign_up
+    def configure_sign_up_params
+      devise_parameter_sanitizer.permit(:sign_up,
+                                        keys: %i[name username email password password_confirmation remember_me avatar
+                                                 cover])
+    end
+
+    # Permit avatar cover for update
+    def configure_account_update_params
+      devise_parameter_sanitizer.permit(:account_update,
+                                        keys: %i[name username email password password_confirmation avatar
+                                                 cover bio locale])
+    end
+
+    # The path used after sign up.
+    # def after_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+
+    # The path used after sign up for inactive accounts.
+    # def after_inactive_sign_up_path_for(resource)
+    #   super(resource)
+    # end
   end
-
-  # Permit avatar cover for update
-  def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:avatar, :cover, :bio])
-  end
-
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
 end

--- a/app/controllers/guests/registrations_controller.rb
+++ b/app/controllers/guests/registrations_controller.rb
@@ -1,65 +1,67 @@
 # frozen_string_literal: true
 
-class Guests::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
-  include Accessible
-  
-  skip_before_action :check_user, only: %i[edit update cancel]
+module Guests
+  class RegistrationsController < Devise::RegistrationsController
+    include Accessible
+    before_action :configure_sign_up_params, only: %i[create]
+    before_action :configure_account_update_params, only: %i[update]
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+    skip_before_action :check_user, only: %i[edit update cancel]
 
-  # POST /resource
-  # def create
-  #   super
-  # end
+    # GET /resource/sign_up
+    # def new
+    #   super
+    # end
 
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
+    # POST /resource
+    # def create
+    #   super
+    # end
 
-  # PUT /resource
-  # def update
-  #   super
-  # end
+    # GET /resource/edit
+    # def edit
+    #   super
+    # end
 
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
+    # PUT /resource
+    # def update
+    #   super
+    # end
 
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
+    # DELETE /resource
+    # def destroy
+    #   super
+    # end
 
-  # protected
+    # GET /resource/cancel
+    # Forces the session data which is usually expired after sign
+    # in to be expired now. This is useful if the user wants to
+    # cancel oauth signing in/up in the middle of the process,
+    # removing all OAuth session data.
+    # def cancel
+    #   super
+    # end
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+    protected
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+    # Permitted params for guests sign-up
+    def configure_sign_up_params
+      devise_parameter_sanitizer.permit(:sign_up, keys: %i[username email password password_confirmation remember_me])
+    end
 
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+    # Permitted params for guests update
+    def configure_account_update_params
+      devise_parameter_sanitizer.permit(:account_update, keys: %i[username email password password_confirmation locale])
+    end
 
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+    # The path used after sign up.
+    # def after_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+
+    # The path used after sign up for inactive accounts.
+    # def after_inactive_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+  end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -42,7 +42,7 @@ class Developer < ApplicationRecord
 
   # validate password strength
   validates :password, password_strength: { min_entropy: 25, use_dictionary: true, min_word_length: 6 },
-                       if: :encrypted_password_changed?
+            if: :encrypted_password_changed?
 
   has_many :bots, dependent: :destroy
   has_many :likes, dependent: :destroy
@@ -51,6 +51,11 @@ class Developer < ApplicationRecord
   validates_length_of :bio, maximum: 512
 
   acts_as_follower
+
+  # Save browser's locale as default user's preference locale
+  before_create do |dev|
+    dev.locale = I18n.locale
+  end
 
   # remove all capitals from usernames
   def downcase_username

--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -23,6 +23,11 @@ class Guest < ApplicationRecord
   validates :password, password_strength: { min_entropy: 25, use_dictionary: true, min_word_length: 6 },
                        if: :encrypted_password_changed?
 
+  # Save browser's locale as default user's preference locale
+  before_create do |guest|
+    guest.locale = I18n.locale
+  end
+
   # remove all capitals from usernames
   def downcase_username
     username.downcase!

--- a/app/views/developers/registrations/edit.html.erb
+++ b/app/views/developers/registrations/edit.html.erb
@@ -1,18 +1,22 @@
 <%= stylesheet_link_tag 'developers' %>
 
+<script>$(function () {
+    $('.selectpicker').selectpicker();
+});</script>
+
 <div class="card">
   <article class="card-body mx-auto" style="max-width: 350px; margin-top: -20px">
-    <img class="card-img-top" src="<%= asset_path('logo.svg')%>" alt="", width="250", height="250">
+    <img class="card-img-top" src="<%= asset_path('logo.svg') %>" alt="" , width="250" , height="250">
     <h4 class="card-title mt-3 text-center">Edit Account</h4>
     <p class="text-center">Change your developer account</p>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <div class="form-group input-group">
-      <div class="input-group-prepend">
+        <div class="input-group-prepend">
           <span class="input-group-text">
             <i class="fa fa-user"></i>
           </span>
-          </div>
-        <%= f.text_field :name, autofocus: true, class: 'form-control', placeholder: 'Full name', type: 'text' %> 
+        </div>
+        <%= f.text_field :name, autofocus: true, class: 'form-control', placeholder: 'Full name', type: 'text' %>
       </div>
       <div class="form-group input-group">
         <div class="input-group-prepend">
@@ -20,7 +24,7 @@
             <i class="far fa-user"></i>
           </span>
         </div>
-        <%= f.text_field :username, class: 'form-control', placeholder: 'Username', type: 'text'%>
+        <%= f.text_field :username, class: 'form-control', placeholder: 'Username', type: 'text' %>
       </div>
       <!-- form-group// -->
       <div class="form-group input-group">
@@ -32,13 +36,13 @@
         <%= f.email_field :email, autocomplete: 'email', class: 'form-control', placeholder: 'Email address', type: 'email' %>
       </div>
       <div class="form-group input-group">
-            <div class="input-group-prepend">
+        <div class="input-group-prepend">
               <span class="input-group-text">
                 <i class="fas fa-book"></i>
               </span>
-              </div>
-              <%= f.text_area :bio , placeholder: 'Bio', class:'form-control' , type: 'Bio' %>
-          </div>
+        </div>
+        <%= f.text_area :bio, placeholder: 'Bio', class: 'form-control', type: 'Bio' %>
+      </div>
       <button class="btn btn-primary btn-block" style="margin-bottom:15px;" type="button" data-toggle="collapse" data-target="#passwords" aria-controls="passwords" aria-expanded="false" aria-label="Toggle navigation">
         Change Password
       </button>
@@ -59,9 +63,12 @@
               <i class="fa fa-lock"></i>
             </span>
           </div>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control', placeholder: 'Repeat new password', type: 'password'%>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control', placeholder: 'Repeat new password', type: 'password' %>
         </div>
       </div>
+      <label>
+        <%= f.select :locale, options_for_select([%w[English en], %w[Português pt]], current_user.locale) %>
+      </label>
       <div class="form-group input-group">
         <div class="input-group-prepend">
           <span class="input-group-text">
@@ -71,11 +78,11 @@
         <%= f.password_field :current_password, autocomplete: "current-passord", class: 'form-control', placeholder: 'Current Password', type: 'password', required: true %>
       </div>
       <div class="custom-file">
-        <%= f.file_field :avatar, class: 'custom-file-input', type: 'file'%>
+        <%= f.file_field :avatar, class: 'custom-file-input', type: 'file' %>
         <label class="custom-file-label" for="customFile">Update avatar</label>
       </div>
       <div class="custom-file" style="margin-top: 10px">
-        <%= f.file_field :cover, class: 'custom-file-input', type: 'file'%>
+        <%= f.file_field :cover, class: 'custom-file-input', type: 'file' %>
         <label class="custom-file-label" for="customFile">Update cover</label>
       </div>
       <!-- form-group// -->
@@ -83,6 +90,6 @@
       <div class="form-group" style="margin-top: 20px">
         <%= f.submit "Update Account", class: 'btn btn-primary btn-block' %>
       </div>
-  <% end %>
+    <% end %>
   </article>
 </div>

--- a/app/views/guests/registrations/edit.html.erb
+++ b/app/views/guests/registrations/edit.html.erb
@@ -46,6 +46,9 @@
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control', placeholder: 'Repeat new password', type: 'password'%>
         </div>
       </div>
+      <label>
+        <%= f.select :locale, options_for_select([%w[English en], %w[Português pt]], current_user.locale) %>
+      </label>
       <div class="form-group input-group">
         <div class="input-group-prepend">
           <span class="input-group-text">

--- a/db/migrate/20210612123551_add_local_to_developers.rb
+++ b/db/migrate/20210612123551_add_local_to_developers.rb
@@ -1,0 +1,5 @@
+class AddLocalToDevelopers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :developers, :locale, :string
+  end
+end

--- a/db/migrate/20210612125317_add_local_to_guests.rb
+++ b/db/migrate/20210612125317_add_local_to_guests.rb
@@ -1,0 +1,5 @@
+class AddLocalToGuests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :guests, :locale, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_130351) do
+ActiveRecord::Schema.define(version: 2021_06_12_125317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_130351) do
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
     t.datetime "locked_at"
+    t.string "locale"
     t.index ["email"], name: "index_developers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_developers_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_developers_on_slug", unique: true
@@ -116,6 +117,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_130351) do
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
     t.datetime "locked_at"
+    t.string "locale"
     t.index ["email"], name: "index_guests_on_email", unique: true
     t.index ["reset_password_token"], name: "index_guests_on_reset_password_token", unique: true
     t.index ["username"], name: "index_guests_on_username", unique: true


### PR DESCRIPTION
App language based on user's preference and browser's config.

When creating an account, the default locale is going to be saved as the user's browser's preferred language (HTTP_ACCEPT_LANGUAGE first option). This value is now saved to DB using before_create on models. 
Added an option to change default language on registrations edit pages. So, the user can switch between available locales and used the preferred one.

PS: I added a simple selector for selecting languages, it looks ugly, so a new issue might be created to fix this selector's layout. In my opinion, it should not be on edit profile's page, but for now we don't have a specific page for changing preferences. 

Closes #317