### PR TITLE
Timezones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,8 +48,6 @@ gem 'file_validators'
 
 gem 'rails-bootstrap-tabs', '~> 0.2.4'
 
-gem 'local_time'
-
 gem 'rack-attack'
 
 gem 'route_downcaser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,6 @@ GEM
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    local_time (2.1.0)
     loofah (2.10.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -295,7 +294,6 @@ DEPENDENCIES
   jbuilder (~> 2.11)
   jquery-rails
   listen (~> 3.5)
-  local_time
   mini_magick
   pg (~> 1.1)
   puma (~> 5.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   before_action :set_locale
   helper_method :current_user
+  before_action :set_timezone
 
   # Returns current user whether it's a guest or a developer
   def current_user
@@ -17,5 +18,12 @@ class ApplicationController < ActionController::Base
   def set_locale
     I18n.locale = current_user.try(:locale) || http_accept_language.compatible_language_from(I18n.available_locales) ||
                   I18n.default_locale
+  end
+
+  # Set timezone for current user
+  # Tries to get timezone from user's preferences. Then, from cookie and if both fails
+  # set it to UTC.
+  def set_timezone
+    Time.zone = current_user.try(:timezone) || cookies[:timezone] || 'UTC'
   end
 end

--- a/app/controllers/developers/registrations_controller.rb
+++ b/app/controllers/developers/registrations_controller.rb
@@ -6,6 +6,7 @@ module Developers
     before_action :configure_sign_up_params, only: %i[create]
     before_action :configure_account_update_params, only: %i[update]
     skip_before_action :check_user, only: %i[edit update cancel]
+    after_action :save_user_timezone, only: :create
 
     # GET /resource/sign_up
     # def new
@@ -41,6 +42,15 @@ module Developers
     #   super
     # end
 
+    private
+
+    # Save user's timezone on sign-up
+    def save_user_timezone
+      return unless resource.persisted?
+
+      resource.update(timezone: cookies[:timezone])
+    end
+
     protected
 
     # Permit avatar and cover for sign_up
@@ -54,7 +64,7 @@ module Developers
     def configure_account_update_params
       devise_parameter_sanitizer.permit(:account_update,
                                         keys: %i[name username email password password_confirmation avatar
-                                                 cover bio locale])
+                                                 cover bio locale timezone])
     end
 
     # The path used after sign up.

--- a/app/controllers/guests/registrations_controller.rb
+++ b/app/controllers/guests/registrations_controller.rb
@@ -5,8 +5,8 @@ module Guests
     include Accessible
     before_action :configure_sign_up_params, only: %i[create]
     before_action :configure_account_update_params, only: %i[update]
-
     skip_before_action :check_user, only: %i[edit update cancel]
+    after_action :save_user_timezone, only: :create
 
     # GET /resource/sign_up
     # def new
@@ -42,6 +42,15 @@ module Guests
     #   super
     # end
 
+    private
+
+    # Save user's timezone on sign-up
+    def save_user_timezone
+      return unless resource.persisted?
+
+      resource.update(timezone: cookies[:timezone])
+    end
+
     protected
 
     # Permitted params for guests sign-up
@@ -51,7 +60,8 @@ module Guests
 
     # Permitted params for guests update
     def configure_account_update_params
-      devise_parameter_sanitizer.permit(:account_update, keys: %i[username email password password_confirmation locale])
+      devise_parameter_sanitizer.permit(:account_update, keys: %i[username email password password_confirmation locale
+                                                                  timezone])
     end
 
     # The path used after sign up.

--- a/app/helpers/developers_helper.rb
+++ b/app/helpers/developers_helper.rb
@@ -1,2 +1,8 @@
+# frozen_string_literal: true
+
+# Helpers for Developers
 module DevelopersHelper
+  def created_at_formatted(created_at)
+    I18n.l(created_at.in_time_zone, format: :date)
+  end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Posts helpers
+module PostsHelper
+  def time_ago(created_at)
+    difference = Time.now.in_time_zone - created_at.in_time_zone
+    if difference < 1.minute
+      I18n.t('time.distance.x_seconds_ago', count: (difference / 1.second).to_i)
+    elsif difference < 1.hour
+      I18n.t('time.distance.x_minutes_ago', count: (difference / 1.minute).to_i)
+    elsif difference < 1.day
+      I18n.t('time.distance.x_hours_ago', count: (difference / 1.hour).to_i)
+    elsif difference < 2.days
+      I18n.l(created_at.in_time_zone, format: :yesterday)
+    else
+      I18n.l(created_at.in_time_zone, format: :date)
+    end
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,12 +13,10 @@ import {  Application} from "stimulus"
 import {  definitionsFromContext} from "stimulus/webpack-helpers"
 import "@fortawesome/fontawesome-free/js/all"
 import 'bootstrap'
-import LocalTime from 'local-time'
 
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
-LocalTime.start()
 
 // stimulus and autocomplete config
 const application = Application.start();
@@ -29,6 +27,7 @@ require('jquery')
 
 // custom js scripts
 require('packs/custom/posts')
+require('packs/custom/timezones')
 
 $(document).ready(function() {
   setTimeout(function() {

--- a/app/javascript/packs/custom/timezones.js
+++ b/app/javascript/packs/custom/timezones.js
@@ -1,0 +1,12 @@
+// Set timezone cookie to expire in 30 days
+function setCookie(key, value) {
+    const expires = new Date();
+    expires.setTime(expires.getTime() + (30 * 24 * 60 * 60 * 1000));
+    document.cookie = key + '=' + value + ';expires=' + expires.toUTCString();
+}
+
+// Get user's timezone and save it to a cookie
+jQuery(function () {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    setCookie('timezone', tz);
+})

--- a/app/views/bots/_bot.html.erb
+++ b/app/views/bots/_bot.html.erb
@@ -13,7 +13,7 @@
           </div>
           <div class="handle"><%= link_to '@' + bot.username, bot_path(bot) %></div>
           <div class="date pt pb"><%= I18n.t('bots.profile.items.joined') %>
-            <%= local_relative_time(bot.created_at, type: 'date') %>
+            <%= created_at_formatted(bot.created_at) %>
           </div>
         </div>
         <div class="dropdown dropright">

--- a/app/views/bots/show.html.erb
+++ b/app/views/bots/show.html.erb
@@ -38,7 +38,7 @@
       </p>
       <p class="card-text">
         <small class="text-muted"><%= I18n.t('bots.profile.items.joined') %>
-          <%= local_relative_time(@bot.created_at, type: 'date') %></small>
+          <%= created_at_formatted(@bot.created_at) %></small>
         •
         <%= link_to '@' + @bot.developer.username, developer_path(@bot.developer) %>
       </p>

--- a/app/views/developers/_developer.html.erb
+++ b/app/views/developers/_developer.html.erb
@@ -13,7 +13,7 @@
           </div>
           <div class="handle"><%= link_to '@' + developer.username, developer_path(developer) %></div>
           <div class="date pt pb"><%= I18n.t('developers.show.joined') %>
-            <%= local_relative_time(developer.created_at, type: 'date') %>
+            <%= created_at_formatted(developer.created_at) %>
           </div>
         </div>
         <div class="dev-content pt">

--- a/app/views/developers/registrations/edit.html.erb
+++ b/app/views/developers/registrations/edit.html.erb
@@ -69,6 +69,9 @@
       <label>
         <%= f.select :locale, options_for_select([%w[English en], %w[Português pt]], current_user.locale) %>
       </label>
+      <label>
+        <%= f.time_zone_select :timezone %>
+      </label>
       <div class="form-group input-group">
         <div class="input-group-prepend">
           <span class="input-group-text">

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -19,7 +19,7 @@
       </div>
       <p class="card-text">
         <small class="text-muted"><%= I18n.t('developers.show.joined') %>
-          <%= local_relative_time(@developer.created_at, type: 'date') %></small>
+          <%= created_at_formatted(@developer.created_at) %></small>
       </p>
     </div>
   </div>

--- a/app/views/guests/registrations/edit.html.erb
+++ b/app/views/guests/registrations/edit.html.erb
@@ -49,6 +49,9 @@
       <label>
         <%= f.select :locale, options_for_select([%w[English en], %w[Português pt]], current_user.locale) %>
       </label>
+      <label>
+        <%= f.time_zone_select :timezone %>
+      </label>
       <div class="form-group input-group">
         <div class="input-group-prepend">
           <span class="input-group-text">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -61,7 +61,7 @@
                 <div class="row fs-sm text-muted ">
                   <p class="fw-lighter fs-6"><%= @post.bot.name %>
                     •
-                    <%= local_time_ago(@post.created_at) %>
+                    <%= time_ago(@post.created_at) %>
                 </div>
               </div>
             </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -13,7 +13,7 @@
           </div>
           <div class="handle"><%= link_to '@' + post.bot.username, bot_path(post.bot) %></div>
           <div class="date pt pb">
-            <%= local_time_ago(post.created_at) %>
+            <%= time_ago(post.created_at) %>
           </div>
         </div>
         <div class="dropdown dropright" style="margin-top: -5px">

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ module Iae
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'America/Sao_Paulo'
     # config.eager_load_paths << Rails.root.join("extras")
 
     # I18n config

--- a/config/locales/defaults/datetime/en.yml
+++ b/config/locales/defaults/datetime/en.yml
@@ -1,0 +1,17 @@
+# English translations related to Date/Time
+
+en:
+  time:
+    distance:
+      x_seconds_ago:
+        one: "a second ago"
+        other: "%{count} seconds ago"
+      x_minutes_ago:
+        one: "a minute ago"
+        other: "%{count} minutes ago"
+      x_hours_ago:
+        one: "an hour ago"
+        other: "%{count} hours ago"
+    formats:
+      yesterday: "Yesterday at %l:%M %p"
+      date: "%b %e, %Y"

--- a/config/locales/defaults/datetime/pt.yml
+++ b/config/locales/defaults/datetime/pt.yml
@@ -1,0 +1,17 @@
+# Portuguese translations related to Date/Time
+
+pt:
+  time:
+    distance:
+      x_seconds_ago:
+        one: "há um segundo"
+        other: "há %{count} segundos"
+      x_minutes_ago:
+        one: "há um minuto"
+        other: "há %{count} minutos"
+      x_hours_ago:
+        one: "há uma hora"
+        other: "há %{count} horas"
+    formats:
+      yesterday: "Ontem às %H:%M"
+      date: "%e de %b, %Y"

--- a/config/locales/models/developer/pt.yml
+++ b/config/locales/models/developer/pt.yml
@@ -11,6 +11,7 @@ pt:
         password: "Senha"
         cover: "Foto de capa"
         password_confirmation: "Confirmação de senha"
+        current_password: "Senha atual"
     errors:
       models:
         developer:
@@ -25,5 +26,7 @@ pt:
             cover:
               minimum_image_size: "deve ser 640x180px no mínimo."
               maximum_image_size: "deve ser 1280x360px no máximo."
+            current_password:
+              invalid: "é inválida"
       messages:
         confirmation: "deve ser igual a senha."

--- a/config/locales/models/guest/pt.yml
+++ b/config/locales/models/guest/pt.yml
@@ -9,6 +9,7 @@ pt:
           username: "Nome de usuário"
           password: "Senha"
           password_confirmation: "Confirmação de senha"
+          current_password: "Senha atual"
     errors:
       models:
         guest:
@@ -18,5 +19,7 @@ pt:
             password:
               password:
                 password_strength: "é muito fraca. Tente novamente com uma senha mais forte."
+            current_password:
+              invalid: "é inválida"
       messages:
         confirmation: "deve ser igual a senha."

--- a/db/migrate/20210617224831_add_time_zone_to_users.rb
+++ b/db/migrate/20210617224831_add_time_zone_to_users.rb
@@ -1,0 +1,6 @@
+class AddTimeZoneToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :guests, :timezone, :string
+    add_column :developers, :timezone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_12_125317) do
+ActiveRecord::Schema.define(version: 2021_06_17_224831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2021_06_12_125317) do
     t.string "unlock_token"
     t.datetime "locked_at"
     t.string "locale"
+    t.string "timezone"
     t.index ["email"], name: "index_developers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_developers_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_developers_on_slug", unique: true
@@ -118,6 +119,7 @@ ActiveRecord::Schema.define(version: 2021_06_12_125317) do
     t.string "unlock_token"
     t.datetime "locked_at"
     t.string "locale"
+    t.string "timezone"
     t.index ["email"], name: "index_guests_on_email", unique: true
     t.index ["reset_password_token"], name: "index_guests_on_reset_password_token", unique: true
     t.index ["username"], name: "index_guests_on_username", unique: true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "bootstrap": "^4.6.0",
     "jquery": "^3.6.0",
     "js-autocomplete": "^1.0.4",
-    "local-time": "^2.1.0",
     "popper.js": "^1.16.1",
     "stimulus": "^2.0.0",
     "turbolinks": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4195,11 +4195,6 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-local-time@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/local-time/-/local-time-2.1.0.tgz#be42f06bf269f9da77cb61ea722aa424dd01d919"
-  integrity sha512-4rB/8EkJIZ8O8Y5q536fSsRbzXOI0cL30l3ZKm4ISPC4D8jYOhRp/MpAaGKAYUvVIqkojT0c7kJk0RlnwtlR2w==
-
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"


### PR DESCRIPTION
### Multiple time zones
**For real, this time.**

Behavior:

- Client makes their first request to the app, a JS script will run on their browser and set a cookie with their timezone
- This cookie has a 30 days lifespan
- When creating an account, the default timezone is going to be the one saved in this cookie. Auto-detected by JS
- User can edit it later, to any timezone they wish
- The app timezone will be set dynamically. In case both strategies fail (user's preference and cookie), the timezone is going to be set as "UTC". (This should only happen in the first access to the app)

Time and date will be displayed translated, following regions preferences as I know (i.e. mm-dd-yyyy and 12 hours clock for English translations).