### PR TITLE
Fix logo loader on homepage

### DIFF
--- a/app/javascript/packs/custom/particles.js
+++ b/app/javascript/packs/custom/particles.js
@@ -1563,7 +1563,7 @@ $(document).ready(function() {
             "nb_sides": 5
           },
           "image": {
-            "src": "assets/logo.png",
+            "src": $("#logo-path").data("pathToAsset"),
             "width": 100,
             "height": 100
           }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,8 @@
 <%= stylesheet_link_tag 'pages' %>
 <%= javascript_pack_tag 'custom/particles' %>
 
+<%= content_tag(:div, '', id: 'logo-path', data:{path_to_asset: asset_path('logo.png')}) %>
+
 <% unless current_developer %>
   <div class="h-100 w-100 position-fixed" id="particles-js" style="top: 0;left:0;z-index:-50;"></div>
 


### PR DESCRIPTION
Loading the logo in particles.js using "assets/logo.png" doesn't work in production because assets are precompiled. The solution I found was to load it using Rails asset_path helper from a .erb file and get its data using tag id in particles.js.