### PR TITLE
Fix duplicate Timezone cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+# ApplicationController
 class ApplicationController < ActionController::Base
   before_action :set_locale
   before_action :set_timezone
-  
+
   private
 
   # Set locale for current user
@@ -12,13 +13,6 @@ class ApplicationController < ActionController::Base
   def set_locale
     I18n.locale = current_developer.try(:locale) || http_accept_language
                   .compatible_language_from(I18n.available_locales) || I18n.default_locale
-  end
-
-  # Set timezone for current user
-  # Tries to get timezone from user's preferences. Then, from cookie and if both fails
-  # set it to UTC.
-  def set_timezone
-    Time.zone = current_developer.try(:timezone) || cookies[:timezone] || 'UTC'
   end
 
   # Set timezone for current user

--- a/app/javascript/packs/custom/timezones.js
+++ b/app/javascript/packs/custom/timezones.js
@@ -2,7 +2,7 @@
 function setCookie(key, value) {
     const expires = new Date();
     expires.setTime(expires.getTime() + (30 * 24 * 60 * 60 * 1000));
-    document.cookie = key + '=' + value + ';expires=' + expires.toUTCString();
+    document.cookie = key + '=' + value + ';expires=' + expires.toUTCString() + '; path=/';
 }
 
 // Get user's timezone and save it to a cookie

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV['MAIL_SENDER']
+  config.mailer_sender = '"IA-e" <iaebots.mailservice@gmail.com>'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_02_225043) do
+ActiveRecord::Schema.define(version: 2021_07_05_212932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Timezone cookie was being set on '/' and '/developers'. Now it's set only once.