### PR TITLE
Redis for cache storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem 'strong_password', '~> 0.0.9'
 
 gem 'http_accept_language'
 
+gem 'redis'
+
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.4.0)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -303,6 +304,7 @@ DEPENDENCIES
   rails-bootstrap-tabs (~> 0.2.7)
   rails-html-sanitizer
   rails-i18n
+  redis
   route_downcaser
   sass-rails (>= 6)
   selenium-webdriver

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,8 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_URL_CACHING", "redis://localhost:6379/0") }
+
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_URL_CACHING", "redis://localhost:6379/0") }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,6 +13,13 @@ services:
             - POSTGRES_DB=iae_development
             - POSTGRES_USER=iae
             - POSTGRES_PASSWORD=password
+    redis:
+        image: redis
+        command: redis-server
+        ports: 
+            - 6379:6379
+        volumes:
+            - redis:/data
     web:
         build:
             context: .
@@ -20,6 +27,7 @@ services:
         image: iae:1.0
         depends_on:
             - db
+            - redis
         ports:
             - 3000:3000
         volumes:
@@ -32,8 +40,10 @@ services:
             - DATABASE_HOST=db
             - DATABASE_NAME=iae_development
             - RAILS_ENV=development
+            - REDIS_URL_CACHING=redis://redis:6379/0
 volumes:
     db_data:
     node_modules:
+    redis:
     iae_uploads:
         external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,13 @@ services:
         volumes:
             - prod_db_data:/var/lib/postgresql/data
         env_file: .env
+    redis:
+        image: redis
+        command: redis-server
+        ports: 
+            - 6379:6379
+        volumes:
+            - redis:/data
     web:
         build:
             context: .
@@ -26,3 +33,4 @@ services:
 volumes:
     prod_db_data:
     prod_node_modules:
+    redis:

--- a/entrypoints/docker-entrypoint.sh
+++ b/entrypoints/docker-entrypoint.sh
@@ -9,5 +9,6 @@ if [ -f tmp/pids/server.pid ]; then
   rm tmp/pids/server.pid
 fi
 
+bundle install
 bundle exec rails db:migrate
 bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
Using a new container running a Redis service to be used as cache storage, placing Rails' default cache.

To run this you can use: docker-compose -f docker-compose-dev.yml up --build

Closes #388 