### PR TITLE
Shrine I18n

### DIFF
--- a/app/models/concerns/usernames_blocklist.rb
+++ b/app/models/concerns/usernames_blocklist.rb
@@ -5,7 +5,7 @@ module UsernamesBlocklist
   def blocklist
     @blocklist ||= %w[password edit admin administrator administrador administradores delete create developer
                       developers desenvolvedor desenvolvedores contact contact-us iaebots iae-bots iae_bots email
-                      recruitment registration registrations session sessions guest guests report reports sign_in
+                      recruitment registration registrations session sessions report reports sign_in
                       sign_up sign-in sign-up staff sysadmin support suporte term terms terms-of-service new
                       terms_of_service termsofservice username user users slug slugs unlock unlocks]
   end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -8,7 +8,23 @@ class AvatarUploader < Shrine
   Shrine.plugin :restore_cached_data
 
   plugin :determine_mime_type, analyzer: :marcel
-  plugin :validation_helpers
+
+  # Override validation helpers translation
+  plugin :validation_helpers, default_messages: {
+    max_size: ->(max) { I18n.t('errors.file.max_size', max: max / (1024 * 1024)) }, # convert size from B to MB
+    min_size: ->(min) { I18n.t('errors.file.min_size', min: min / 1024) }, # convet size from B to KB
+    max_width: ->(max) { I18n.t('errors.file.max_width', max: max) },
+    min_width: ->(min) { I18n.t('errors.file.min_width', min: min) },
+    max_height: ->(max) { I18n.t('errors.file.max_height', max: max) },
+    min_height: ->(min) { I18n.t('errors.file.min_height', min: min) },
+    max_dimensions: ->(dims) { I18n.t('errors.file.max_dimensions', dims: dims) },
+    min_dimensions: ->(dims) { I18n.t('errors.file.min_dimensions', dims: dims) },
+    mime_type_inclusion: ->(list) { I18n.t('errors.file.mime_type_inclusion', list: list.join(', ')) },
+    mime_type_exclusion: ->(list) { I18n.t('errors.file.mime_type_exclusion', list: list.join(', ')) },
+    extension_inclusion: ->(list) { I18n.t('errors.file.extension_inclusion', list: list.join(', ')) },
+    extension_exclusion: ->(list) { I18n.t('errors.file.extension_exclusion', list: list.join(', ')) }
+  }
+
   plugin :remove_invalid # remove invalid cached files
   plugin :store_dimensions
   plugin :default_url
@@ -18,7 +34,6 @@ class AvatarUploader < Shrine
   Attacher.validate do
     validate_min_size 1 * 1024 # 1 KB
     validate_max_size 10 * 1024 * 1024 # 10MB
-    validate_extension %w[jpg jpeg png webp gif]
     validate_max_dimensions [5000, 5000] if validate_mime_type %w[image/jpeg image/png image/webp image/gif]
   end
 

--- a/app/uploaders/cover_uploader.rb
+++ b/app/uploaders/cover_uploader.rb
@@ -8,7 +8,23 @@ class CoverUploader < Shrine
   Shrine.plugin :restore_cached_data
 
   plugin :determine_mime_type, analyzer: :marcel
-  plugin :validation_helpers
+
+  # Override validation helpers translation
+  plugin :validation_helpers, default_messages: {
+    max_size: ->(max) { I18n.t('errors.file.max_size', max: max / (1024 * 1024)) }, # convert size from B to MB
+    min_size: ->(min) { I18n.t('errors.file.min_size', min: min / 1024) }, # convert size from B to KB
+    max_width: ->(max) { I18n.t('errors.file.max_width', max: max) },
+    min_width: ->(min) { I18n.t('errors.file.min_width', min: min) },
+    max_height: ->(max) { I18n.t('errors.file.max_height', max: max) },
+    min_height: ->(min) { I18n.t('errors.file.min_height', min: min) },
+    max_dimensions: ->(dims) { I18n.t('errors.file.max_dimensions', dims: dims) },
+    min_dimensions: ->(dims) { I18n.t('errors.file.min_dimensions', dims: dims) },
+    mime_type_inclusion: ->(list) { I18n.t('errors.file.mime_type_inclusion', list: list.join(', ')) },
+    mime_type_exclusion: ->(list) { I18n.t('errors.file.mime_type_exclusion', list: list.join(', ')) },
+    extension_inclusion: ->(list) { I18n.t('errors.file.extension_inclusion', list: list.join(', ')) },
+    extension_exclusion: ->(list) { I18n.t('errors.file.extension_exclusion', list: list.join(', ')) }
+  }
+
   plugin :remove_invalid # remove invalid cached files
   plugin :store_dimensions
   plugin :default_url
@@ -18,8 +34,7 @@ class CoverUploader < Shrine
   Attacher.validate do
     validate_min_size 1 * 1024 # 1KB
     validate_max_size 10 * 1024 * 1024 # 10MB
-    validate_extension %w[jpg jpeg png webp gif]
-    if validate_mime_type %w[image/jpeg image/png image/webp image/gif]
+    if validate_mime_type %w[image/jpeg image/png image/webp]
       validate_max_dimensions [5000, 5000]
       validate_min_dimensions [640, 180]
     end

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -1,4 +1,4 @@
-# English efault messages
+# English default messages
 
 en:
   errors:
@@ -8,3 +8,16 @@ en:
         not_saved:
           one: "1 error found"
           other: "%{count} errors found"
+    file:
+      max_size: "is  too big. Max file size is %{max}MB"
+      min_size: "is too small. Min file size is %{min}KB"
+      max_width: "is too wide. Max allowed width is %{max}"
+      min_width: "is too small. Min allowed width is %{min}"
+      max_height: "is too tall. Max allowed height is %{max}"
+      min_height: "is too short. Min allowed height is %{min}"
+      max_dimensions: "is too big. Max allowed dimensions are %{dims}"
+      min_dimensions: "is too small. Min allowed dimensions are %{dims}"
+      mime_type_inclusion: "file type is not allowed. Allowed types are %{list}"
+      mime_type_exclusion: "These file types are not allowed %{list}"
+      extension_inclusion: "file extension is not allowed. Allowed extensions are %{list}"
+      extension_exclusion: "These file extensions are not allowed %{list}"

--- a/config/locales/defaults/pt.yml
+++ b/config/locales/defaults/pt.yml
@@ -8,3 +8,16 @@ pt:
         not_saved:
           one: "1 erro encontrado"
           other: "%{count} erros encontrados"
+    file:
+      max_size: "é muito grande. O tamanho máximo permitido é %{max}MB"
+      min_size: "é muito pequeno(a). O tamanho mínimo permitido é %{min}KB"
+      max_width: "é muito grande. A largura máxima permitida é %{max}"
+      min_width: "é muito pequeno(a). A largura mínima permitida é %{min}"
+      max_height: "é muito grande. A altura máxima permitida é %{max}"
+      min_height: "é muito pequeno(a). A altura mínima permitida é %{min}"
+      max_dimensions: "é muito grande. As dimensões máximas permitidas são %{dims}"
+      min_dimensions: "é muito pequeno(a). As dimensões mínimas permitidas são %{dims}"
+      mime_type_inclusion: "possui tipo de arquivo não permitido. Os tipos permitidos são %{list}"
+      mime_type_exclusion: "Estes tipos de arquivos não são permitidos: %{list}"
+      extension_inclusion: "possui extensão de arquivo não permitida. As extensões de arquivos permtidias são %{list}"
+      extension_exclusion: "Estas extensões de arquivos não são permitidas %{list}"

--- a/config/locales/models/developer/pt.yml
+++ b/config/locales/models/developer/pt.yml
@@ -10,7 +10,8 @@ pt:
         username: "Nome de usuário"
         friendly_id: "Nome de usuário"
         password: "Senha"
-        cover: "Foto de capa"
+        avatar: "O avatar"
+        cover: "A capa"
         password_confirmation: "Confirmação de senha"
         current_password: "Senha atual"
     errors:

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -5,7 +5,6 @@ en:
     nav-bar:
       items:
         developer: "Developer"
-        guest: "Guest"
         account: "My account"
         log-out: "Log out"
     alert:

--- a/config/locales/views/layouts/pt.yml
+++ b/config/locales/views/layouts/pt.yml
@@ -5,7 +5,6 @@ pt:
     nav-bar:
       items:
         developer: "Desenvolvedor"
-        guest: "Convidado"
         account: "Minha conta"
         log-out: "Sair"
     alert:

--- a/config/locales/views/pages/home/en.yml
+++ b/config/locales/views/pages/home/en.yml
@@ -7,7 +7,6 @@ en:
       slogan: "Where bots do bots things... Whatever it means"
     buttons:
       developer: "Dev"
-      guest: "Guest"
     features:
       post: "Enjoy the posts"
       like: "Like the posts"

--- a/config/locales/views/pages/home/pt.yml
+++ b/config/locales/views/pages/home/pt.yml
@@ -7,7 +7,6 @@ pt:
       slogan: "Onde bots fazem coisas de bots... O que quer que sejam"
     buttons:
       developer: "Desenvolvedor"
-      guest: "Convidado"
     features:
       post: "Apreciar as publicações"
       like: "Curtir as publicações"


### PR DESCRIPTION
**Add translations for Shrine validation errors**

Some more changes were made:
- Cover can no longer be GIFs
- Removed file extension validation, only MIME type validation should be enough (it was reproducing two equal error messages)
- Remove some references to "Guest" in static files