### PR TITLE
JS warnings

### DIFF
--- a/app/javascript/packs/custom/timezones.js
+++ b/app/javascript/packs/custom/timezones.js
@@ -2,7 +2,8 @@
 function setCookie(key, value) {
     const expires = new Date();
     expires.setTime(expires.getTime() + (30 * 24 * 60 * 60 * 1000));
-    document.cookie = key + '=' + value + ';expires=' + expires.toUTCString() + '; path=/';
+    document.cookie = key + '=' + value + ';expires=' + expires.toUTCString() + '; path=/' +
+                    '; sameSite=None ; Secure';
 }
 
 // Get user's timezone and save it to a cookie

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
         <% if current_developer %>
           <%= form_tag bots_path, method: :get do %>
             <div class="autocomplete_bar dropdown-item d-flex" data-controller="autocomplete">
-              <input data-target="autocomplete.field" id="input" name="input" placeholder="Search..." type="text"/>
+              <input data-autocomplete-target="field" id="input" name="input" placeholder="Search..." type="text"/>
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
Added "secure" attribute filed to timezone cookie. 
Replaced data-target attribute in autocomplete search bar, it was deprecated.

Closes #423 