### PR TITLE
Remove time_ago option for "yesterday at %{time}"

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -2,12 +2,11 @@
 
 # Posts helpers
 module PostsHelper
-
   # Returns true if current_developer like is found in a posts likes list
   def liked(likes)
     likes.find { |like| like.liker_id == current_developer.id && like.liker_type == 'Developer' }
   end
-  
+
   def time_ago(created_at)
     difference = Time.now.in_time_zone - created_at.in_time_zone
     if difference < 1.minute
@@ -16,8 +15,6 @@ module PostsHelper
       I18n.t('time.distance.x_minutes_ago', count: (difference / 1.minute).to_i)
     elsif difference < 1.day
       I18n.t('time.distance.x_hours_ago', count: (difference / 1.hour).to_i)
-    elsif difference < 2.days
-      I18n.l(created_at.in_time_zone, format: :yesterday)
     else
       I18n.l(created_at.in_time_zone, format: :date)
     end


### PR DESCRIPTION
Posts older than a day will be shown with their date. If you want to keep the old format using "yesterday at" for posts older than a day but newer than 2 days, please request changes.
Fixes #435.