### PR TITLE
fix cover on mobile 

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -184,7 +184,7 @@ a{
   -o-object-fit: cover;
   object-fit: cover;
   -o-object-position: 50% 100%;
-  object-position: 50% 100%;
+  object-position: 50% 50%;
 }
 .cover-img-cropper{
   width: 100%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -179,14 +179,16 @@ a{
 .resource-cover-responsive{
   display: block;
   width: 100%;
-  min-width: 640px;
   height: auto;
   max-height: 180px;
   -o-object-fit: cover;
   object-fit: cover;
-  -o-object-position: 50% 50%;
-  object-position: 50% 50%;
-}	
+  -o-object-position: 50% 100%;
+  object-position: 50% 100%;
+}
+.cover-img-cropper{
+  width: 100%;
+}
 
 .resource-cardbox-base{	
   ul{

--- a/app/views/bots/show.html.erb
+++ b/app/views/bots/show.html.erb
@@ -1,8 +1,8 @@
 <%= stylesheet_link_tag 'profiles' %>
 
 <div class="col d-flex justify-content-center page">
-  <div id="profile-card" class="card">
-    <div class="cover-img-cropper">
+  <div id="profile-card" class="card w-100">
+    <div>
       <%= image_tag (@bot.cover_url(:cover) || @bot.cover_url || 'default_cover.png'), class: 'card-img-top resource-cover-responsive', id: 'profile-card-img-top' %>
     </div>
     <div class="card-body">

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -1,8 +1,8 @@
 <%= stylesheet_link_tag 'profiles' %>
 
 <div class="col d-flex justify-content-center page">
-  <div id="profile-card" class="card">
-    <div class="cover-img-cropper">
+  <div id="profile-card" class="card w-100">
+    <div>
       <%= image_tag (@developer.cover_url(:cover) || @developer.cover_url || 'default_cover.png'), class: 'card-img-top resource-cover-responsive', id: 'profile-card-img-top' %>
     </div>
     <div class="card-body">


### PR DESCRIPTION
Just add the `w-100` bootstrap class to profile card and remove `min-width: 640px` (which is horrible by the way). fix #445 

Now the cover takes the half down of cover image no longer the center. Example:
> Before
> ![image](https://user-images.githubusercontent.com/26260636/135328330-700e34b2-1b92-44e1-a2fa-bd4c19f433b7.png)

> Now 
![image](https://user-images.githubusercontent.com/26260636/135328483-d0578b06-59fd-4dec-b5d2-f0f96f161959.png)

I think it's an easy way to standardize the covers until we do something more elaborate, like letting the user select what should be shown. But it can be easily changed.
